### PR TITLE
fix(java): pin spring-security-config with its four siblings

### DIFF
--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -173,6 +173,23 @@
                 <version>6.5.11</version>
             </dependency>
 
+            <!-- Not a direct dependency of any module here: it arrives in the sample through
+                 the spring-boot-dependencies BOM that module imports. Pinned anyway, and this
+                 is load-bearing — while it was unpinned, Dependabot's spring-security group
+                 moved the four artifacts above and left this one wherever the Boot BOM put it.
+                 The result (#1464) was spring-security-config 6.5.2 against
+                 spring-security-web 7.x, and since 7 removed
+                 HandlerMappingIntrospectorRequestTransformer from -web, the old config module
+                 looked for a class that no longer existed and NO ApplicationContext started
+                 at all. Same trap as the jackson comment in the sample's own pom: pin the
+                 whole family, or the half you did not pin drifts.
+                 Keep this version identical to its four siblings. -->
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-config</artifactId>
+                <version>6.5.11</version>
+            </dependency>
+
             <!-- Spring Boot Auto-configuration -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Root cause of the Spring Security 7 failure in #1464 — and **it is not the one #1468 was opened with.**

## What actually happened

Going back to that run's log rather than reasoning from the migration guide: all three sample tests failed identically, and **none of them ran**. The ApplicationContext never started.

```
Caused by: java.lang.NoClassDefFoundError:
  org/springframework/security/web/access/HandlerMappingIntrospectorRequestTransformer
    at ...WebMvcSecurityConfiguration.postProcessBeanDefinitionRegistry
       ~[spring-security-config-6.5.2.jar]
```

`spring-security-config` was still on **6.5.2** while `spring-security-web` moved to **7.x**, and 7 removed that class from `-web`. The old config module went looking for a class the new web module no longer ships.

That is **version skew** — precisely the failure #1456's grouping exists to prevent — arriving through a path grouping cannot see.

## Why grouping missed it

`groups: spring-security: "org.springframework.security:*"` moves the four artifacts pinned in this pom. `spring-security-config` is not one of them: it isn't a direct dependency of any module in the reactor, and reaches `idenplane-java-spring-sample` **only through the `spring-boot-dependencies` BOM that module imports** (it needs `idenplane-java` as its parent for reactor resolution, so it can't also extend `spring-boot-starter-parent`).

Dependabot never proposed it, so it sat wherever the Boot BOM left it while its siblings moved.

The sample's own pom already documents this exact trap for jackson — `jackson-databind` pinned directly, `jackson-annotations`/`jackson-core` left to the BOM, `ObjectMapper` failing at class-init. Same shape, different artifact.

## The fix

Pin it at `6.5.11` alongside the other four. **This changes nothing today** — the Boot BOM resolves the same version — which is the point: a no-op now, and the difference between a working upgrade and a dead context later.

## Two corrections to the record

Both came out of this investigation, and both matter for whoever picks up #1468:

- **"Security 7 breaks the authorities mapping" was wrong.** That reading came from `SpringBootSampleApplicationTests:89` in #1445's output — a context-load failure surfacing at that line, not an assertion failure. `IdenplaneAuthoritiesConverter` and `IdenplaneAutoConfiguration` are **not** known to be broken; the context never got far enough to exercise them.
- `JwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(Converter<Jwt, Collection<GrantedAuthority>>)` **still exists unchanged** in Spring Security 7.0.7 ([API docs](https://docs.spring.io/spring-security/reference/7.0/api/java/org/springframework/security/oauth2/server/resource/authentication/JwtAuthenticationConverter.html)), so the SDK's converter signature needs no change.

#1468 has been updated with the full findings and a corrected checklist.

## Verification

Maven isn't available on the machine this was prepared on, so verification is the **`Java SDK`** job's `mvn -B verify` across the whole reactor, the sample included. Not merging until that's green.

Refs #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)