### PR TITLE
probe: does Spring Security 7 actually break this SDK?

### DIFF
--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -152,25 +152,25 @@
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-core</artifactId>
-                <version>6.5.11</version>
+                <version>7.1.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-web</artifactId>
-                <version>6.5.11</version>
+                <version>7.1.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-oauth2-jose</artifactId>
-                <version>6.5.11</version>
+                <version>7.1.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-oauth2-resource-server</artifactId>
-                <version>6.5.11</version>
+                <version>7.1.0</version>
             </dependency>
 
             <!-- Not a direct dependency of any module here: it arrives in the sample through
@@ -187,7 +187,7 @@
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-config</artifactId>
-                <version>6.5.11</version>
+                <version>7.1.0</version>
             </dependency>
 
             <!-- Spring Boot Auto-configuration -->


### PR DESCRIPTION
**Draft, not for merge.** This exists to get an answer, not to land a change.

## The question

#1468 has claimed since it was opened that Spring Security 7 breaks `IdenplaneAuthoritiesConverter`. That claim has **never been tested** — because every attempt to test it died before the tests ran:

| attempt | what happened |
|---|---|
| #1445 | moved `spring-security-oauth2-resource-server` alone → context failed to load |
| #1464 | grouped move, but `spring-security-config` stayed on 6.5.2 → `NoClassDefFoundError`, no test ran |

Both were version skew, not incompatibility. #1496 pinned `spring-security-config` alongside its four siblings, so **for the first time the whole family can actually move together.**

## What this branch does

Moves all five `org.springframework.security` artifacts to `7.1.0`. One line each, nothing else.

## What the result means

- **`Java SDK` green** → Security 7 is fine here. `IdenplaneAuthoritiesConverter` and `IdenplaneAutoConfiguration` need no changes, and #1468 shrinks to the Boot 4 `TestRestTemplate` work plus a deliberate coordinated bump.
- **`Java SDK` red** → we finally have the *real* failure, with a stack trace from code that actually executed, instead of a guess inherited from a misread log line.

Either way the ambiguity ends. The branch gets deleted after; the actual upgrade will be its own PR with Boot 4 moving alongside.

Refs #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)