### PR TITLE
ci: fix the two checks blocking the dev → main release PR

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -93,7 +93,22 @@ jobs:
           EOF
 
       - name: Checkout base branch
-        run: git checkout origin/${{ github.base_ref }} -- .
+        # `git checkout <ref> -- .` only overwrites files that exist in the ref.
+        # Files ADDED by this PR survive it, so the base build ends up compiling
+        # new source against the base branch's schema and dependencies — which
+        # fails for reasons that have nothing to do with the API surface.
+        #
+        # #1495 hit exactly that: src/proxy-auth/ (added in #1486) stayed behind
+        # and the base build died with "Module '@prisma/client' has no exported
+        # member 'ProxyApplication'". The check was reporting a broken base,
+        # not a breaking change.
+        #
+        # `git clean` afterwards removes the leftovers. -d for directories, -x
+        # so ignored files go too — but node_modules is re-installed on the very
+        # next step, and keeping it would be the only reason to omit -x.
+        run: |
+          git checkout origin/${{ github.base_ref }} -- .
+          git clean -fdx -e node_modules
 
       - name: Install dependencies (base)
         run: npm ci

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -57,11 +57,20 @@ jobs:
           # never pure-uppercase with no lowercase or mixed-case characters. Matched
           # without anchoring to end-of-line, since trailing punctuation (closing
           # backtick/paren, a comment continuing past it) shouldn't defeat this.
+          #
+          # Also excludes values that say in themselves that they are throwaway —
+          # `...-do-not-use-in-production`, `demo`, `example`, and friends. The
+          # runnable examples need working credentials in their compose files, and
+          # #1495 failed on examples/forward-auth-traefik's. This filters on the
+          # VALUE, deliberately, not on the path: excluding examples/ wholesale
+          # would hide a genuine leak committed there, which is exactly the kind
+          # of place one gets committed.
           HITS=$(git diff origin/main...HEAD \
               -- . ':(exclude)*.example' ':(exclude)*.sample' ':(exclude)*.template' ':(exclude)*.dist' \
             | grep -E '^\+[^+]' \
             | grep -iE '(api[_-]?key|secret|password|token|bearer)[^A-Za-z]*[:=][^A-Za-z]*[A-Za-z0-9_-]{20,}' \
-            | grep -vE '[:=][[:space:]]*"?[A-Z][A-Z0-9_]{19,}("?([^a-zA-Z]|$))' || true)
+            | grep -vE '[:=][[:space:]]*"?[A-Z][A-Z0-9_]{19,}("?([^a-zA-Z]|$))' \
+            | grep -vE '(^|[^a-zA-Z])(demo|example|sample|dummy|placeholder|do-not-use-in-production|change-in-production|quickstart-dev)([^a-zA-Z]|$)' || true)
           if [ -n "$HITS" ]; then
             echo "::error::Possible secret leaked in diff:"
             echo "$HITS"


### PR DESCRIPTION
#1495 (`dev` → `main`, carrying today's work) fails two checks. Neither reports a real problem with the code — both are genuine bugs in the checks themselves.

## 1. API Breaking Change Detection was building a broken base

The step does `git checkout origin/<base> -- .`, which **only overwrites files that exist in the base ref**. Files *added* by the PR survive it.

So `src/proxy-auth/` (added in #1486) stayed behind, and the base build compiled brand-new source against `main`'s Prisma schema:

```
Module '"@prisma/client"' has no exported member 'ProxyApplication'
Property 'proxyApplication' does not exist on type 'PrismaService'
```

That isn't a breaking change — it's a base tree that never existed.

**Fix:** `git clean -fdx -e node_modules` after the checkout. `node_modules` is excluded because the very next step reinstalls it; that's the only reason `-x` needs an exception.

Any PR adding a source file has been hitting this. #1495 is just the first where the added files also needed a schema change to compile, so it failed loudly instead of silently comparing the wrong thing.

## 2. The secret scanner flagged demo credentials

The runnable examples need working credentials in their compose files, and `examples/forward-auth-traefik` (#1488) has them:

```
ADMIN_API_KEY: forward-auth-demo-admin-key-do-not-use-in-production
"clientSecret": "whoami-proxy-demo-secret"
```

Now excluded — **on the value, not the path.** Values that say in themselves they're throwaway (`demo`, `example`, `sample`, `dummy`, `placeholder`, `do-not-use-in-production`, `change-in-production`, `quickstart-dev`) are skipped.

Excluding `examples/` wholesale would have been easier and worse: it's exactly the kind of directory a real credential gets committed to by accident.

### Verified in both directions before pushing

| | |
|---|---|
| **allowed** | the four #1495 values · `quickstart-dev-admin-key` · `server-password: MAVEN_CENTRAL_PASSWORD` (env var *name*, not a value) |
| **still flagged** | a Stripe-shaped live key · a bare 36-char `client_secret` · a plaintext password · a production-looking 32-hex `ADMIN_API_KEY` |

## Unrelated gap, deliberately left alone

While testing I noticed `Authorization: Bearer <jwt>` **never matched the detector in the first place** — its value doesn't follow a `:` or `=` directly, so the `[:=]` in the pattern never fires. Pre-existing, out of scope for this PR, worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
