### PR TITLE
ci: actually reset the tree to the base ref in the breaking-change check

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -93,22 +93,23 @@ jobs:
           EOF
 
       - name: Checkout base branch
-        # `git checkout <ref> -- .` only overwrites files that exist in the ref.
-        # Files ADDED by this PR survive it, so the base build ends up compiling
-        # new source against the base branch's schema and dependencies — which
-        # fails for reasons that have nothing to do with the API surface.
+        # Switch the whole working tree to the base ref, rather than
+        # `git checkout <ref> -- .`.
         #
-        # #1495 hit exactly that: src/proxy-auth/ (added in #1486) stayed behind
-        # and the base build died with "Module '@prisma/client' has no exported
-        # member 'ProxyApplication'". The check was reporting a broken base,
-        # not a breaking change.
+        # That pathspec form only overwrites files that EXIST in the ref, so
+        # files added by the PR survive it. The base build then compiles
+        # brand-new source against the base branch's schema, and fails for
+        # reasons that have nothing to do with the API surface — #1495 died on
+        # "Module '@prisma/client' has no exported member 'ProxyApplication'"
+        # because src/proxy-auth/ (added in #1486) stayed behind.
         #
-        # `git clean` afterwards removes the leftovers. -d for directories, -x
-        # so ignored files go too — but node_modules is re-installed on the very
-        # next step, and keeping it would be the only reason to omit -x.
-        run: |
-          git checkout origin/${{ github.base_ref }} -- .
-          git clean -fdx -e node_modules
+        # #1508 tried to fix this with `git clean -fdx`, which does not work:
+        # clean removes UNTRACKED files, and those files are tracked on the PR
+        # branch. Nothing short of moving HEAD actually reshapes the tree.
+        #
+        # -f discards the current-branch worktree, which is intentional: the
+        # spec for it was already generated two steps ago.
+        run: git checkout -f origin/${{ github.base_ref }}
 
       - name: Install dependencies (base)
         run: npm ci


### PR DESCRIPTION
**My fix in #1508 did not work.** Worth stating plainly why.

I reached for `git clean -fdx` to remove files the PR added — but `clean` removes **untracked** files, and those files are *tracked* on the PR branch. The step ran, the command succeeded, and nothing changed. #1495 failed again with the identical error.

## The actual problem is the pathspec form

```bash
git checkout origin/main -- .
```

This overwrites files that **exist in the ref** and leaves everything else alone. A file added by the PR is neither overwritten (absent from the ref) nor cleaned (tracked here) — so it survives into the base build and compiles against the base branch's schema:

```
Module '"@prisma/client"' has no exported member 'ProxyApplication'
Property 'proxyApplication' does not exist on type 'PrismaService'
```

Nothing short of moving `HEAD` reshapes the tree.

```diff
-  run: |
-    git checkout origin/${{ github.base_ref }} -- .
-    git clean -fdx -e node_modules
+  run: git checkout -f origin/${{ github.base_ref }}
```

`-f` discards the current-branch worktree, which is fine: its spec was already generated two steps earlier.

## Verified by simulation, not another CI round trip

Checking out `origin/main` this way locally:

- removes `src/proxy-auth/` ✅
- leaves a schema with **no** `ProxyApplication` model ✅

Which is exactly the state the base build needs. I checked this rather than assuming, having just assumed wrong once.

## Scope

Any PR adding a source file has been affected. It only surfaced now because #1495's added files *also* required a schema change to compile — before that, the check was quietly diffing a tree that never existed, and reporting whatever that produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)