### PR TITLE
docs: contributor setup guide and coding standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,14 +40,16 @@ cp .env.example .env
 docker compose up -d
 ```
 
-4. **Run database migrations**
+4. **Run migrations and seed development data**
 ```bash
-npm run db:migrate
+npm run db:setup
 ```
 
-5. **Seed development data**
+Or separately, if you only want one of them:
+
 ```bash
-npm run db:seed
+npm run prisma:migrate   # apply migrations
+npm run prisma:seed      # seed development data
 ```
 
 6. **Start development server**
@@ -219,13 +221,13 @@ For the full module map, grouped by concern, with a system diagram, see the [Arc
 
 ```bash
 # Create a new migration
-npm run db:migrate:create -- --name add_new_table
+npm run prisma:migrate -- --name add_new_table
 
 # Apply migrations
-npm run db:migrate
+npm run prisma:migrate
 
-# Reset database (development only)
-npm run db:reset
+# Reset database (development only) — drops, re-migrates and re-seeds
+npx prisma migrate reset
 ```
 
 ## Reporting Issues

--- a/docs/docs/contributing/coding-standards.mdx
+++ b/docs/docs/contributing/coding-standards.mdx
@@ -1,0 +1,131 @@
+---
+id: coding-standards
+title: Coding Standards
+description: What a change to Idenplane is expected to look like — naming, module structure, testing expectations, and the PR checklist, as the tooling actually enforces them.
+---
+
+# Coding Standards
+
+Written from what the repo enforces and what its existing code does, not from what would be nice. Where the tooling doesn't enforce something, that's said plainly, because a rule nobody checks is a rule that drifts.
+
+## What the tooling actually enforces
+
+Run before pushing. CI runs all of these:
+
+```bash
+npm run lint         # eslint + prettier, errors fail the build
+npm test             # jest
+npm run build        # tsc via nest build
+```
+
+**ESLint** (`eslint.config.mjs`):
+
+| rule | level |
+|---|---|
+| `prettier/prettier` | **error** — formatting is not a matter of taste here |
+| `@typescript-eslint/no-unused-vars` | **error**, `_`-prefixed names exempt |
+| `@typescript-eslint/no-floating-promises` | warn |
+| `@typescript-eslint/no-unsafe-argument` | warn |
+| `@typescript-eslint/no-explicit-any` | **off** |
+
+**TypeScript** (`tsconfig.json`): `strictNullChecks` and `noImplicitAny` are on. Full `strict` is not.
+
+:::note `any` is allowed, and used
+`CONTRIBUTING.md` says "no `any`". The linter disagrees — the rule is off, and there are ~22 explicit `any` annotations in `src/`. Treat it as: **don't reach for `any` first**, and don't add one where a real type is obvious. But you will find it in the codebase, mostly at boundaries where a third-party type is wrong or missing, and adding one there isn't a review failure.
+
+`noImplicitAny` *is* on, so an *accidental* `any` from an un-annotated parameter is still a build error. That's the line the tooling draws.
+:::
+
+## Backend module structure
+
+`src/` has ~60 NestJS modules. A new one follows the same shape as its neighbours:
+
+```
+src/<feature>/
+  <feature>.module.ts        wires it up; imports what it needs
+  <feature>.controller.ts    HTTP layer — no business logic
+  <feature>.service.ts       business logic; where Prisma is called
+  <feature>.service.spec.ts  unit tests, colocated
+  dto/
+    create-<feature>.dto.ts  class-validator decorators
+    update-<feature>.dto.ts  usually PartialType(OmitType(Create..., [...]))
+```
+
+Then register it in `src/app.module.ts`.
+
+Conventions worth copying rather than re-deriving:
+
+- **Controllers stay thin.** Guards, decorators, Swagger annotations, delegate to the service. If a controller has an `if` that isn't a guard clause, it probably belongs in the service.
+- **Realm scoping is a guard, not a parameter you check.** `@UseGuards(RealmGuard)` plus `@CurrentRealm() realm: Realm`. Never read `realmName` from params yourself.
+- **Admin endpoints** live under `admin/realms/:realmName/<feature>` with `AdminApiKeyGuard`. Public ones live under `realms/:realmName/<feature>` with `@Public()`.
+- **Rate limiting is per-method where it matters.** A class-level `@RateLimitByIp()` covers every route, which is wrong for anything a proxy or a poller calls on every request — see the comment in `src/proxy-auth/proxy-auth.controller.ts` for a case where it would have throttled an entire application.
+- **DTO validation is not optional.** Every request body goes through a class-validator DTO. The global `ValidationPipe` strips unknown properties; a field you forget to declare is a field that silently disappears.
+
+## Prisma
+
+- `prisma/schema.prisma` is the single source of truth. Never hand-edit generated client code.
+- After changing the schema: `npm run prisma:generate`. `Property 'x' does not exist on type 'PrismaService'` almost always means you skipped it.
+- **Migrations are additive.** Adding a column or table is routine. Dropping or renaming one needs a plan for deployed instances — say so in the PR rather than leaving the reviewer to notice.
+- Name migrations for what they do: `add_proxy_applications`, not `update_schema`.
+- Store secrets as hashes, not plaintext. Session tokens use SHA-256 (`CryptoService.sha256`); passwords use Argon2id. Anything needing to be read back later uses `CryptoService.encrypt` (AES-256-GCM).
+
+## Admin console
+
+- React Query for server state — `useQuery` / `useMutation`, keyed by `[resource, realmName]`. No `useEffect` fetching.
+- Semantic Tailwind tokens (`bg-surface`, `text-fg`, `bg-danger-soft`), never raw colours. Dark mode comes free; a hardcoded `bg-white` breaks it.
+- Every route in `App.tsx` needs a nav entry in `Layout.tsx` — `src/__tests__/routes.test.ts` enforces this and will fail the build otherwise. Detail pages and `/new` pages are exempt by existing rules.
+- Don't export a helper from a page component file. It breaks React Fast Refresh (`react-refresh/only-export-components`); put it in `src/utils/`.
+
+## Testing
+
+| suite | command | needs |
+|---|---|---|
+| backend unit | `npm test` | nothing |
+| backend e2e | `npm run test:e2e` | Postgres running |
+| admin console | `cd admin-ui && npm test` | nothing (MSW mocks the API) |
+| Java SDK | `cd packages/idenplane-java && ./mvnw verify` | Java 17 |
+
+**Coverage gates:** only the Java SDK has one — jacoco, 80% line coverage, enforced in `pom.xml`. TypeScript coverage is collected but not gated. That's not permission to skip tests; it means review is the only thing catching an untested change.
+
+What's expected:
+
+- **New service method → unit test.** Mock Prisma, assert the behaviour, not the implementation.
+- **New endpoint → controller test or e2e**, depending on whether the interesting part is the wiring or the flow.
+- **Bug fix → a test that fails without the fix.** Otherwise nothing stops it coming back.
+- **Security-adjacent code → test the refusals**, not just the happy path. A session validator needs a test proving it rejects an expired session, one from a different application, and one belonging to a disabled user — the passing case is the easy half.
+
+Use the shared Prisma mock (`src/prisma/prisma.mock.ts`) rather than hand-rolling one, and add your model to it if it's missing.
+
+## Commits and PRs
+
+Conventional commits, as `CONTRIBUTING.md` describes:
+
+```
+type(scope): short description
+```
+
+The body is worth more than the subject. **Say why, not what** — the diff already shows what. If you rejected an alternative approach, one line about why saves the next person from trying it.
+
+Before opening a PR:
+
+- [ ] `npm run lint` clean
+- [ ] `npm test` passes
+- [ ] `npm run build` passes
+- [ ] Touched admin-ui? `cd admin-ui && npm run lint && npm test`
+- [ ] Touched Java? `cd packages/idenplane-java && ./mvnw verify`
+- [ ] Schema change? Migration committed, and it's additive (or the PR explains the plan)
+- [ ] New env var? Added to `.env.example` **and** the config docs
+- [ ] Behaviour change? Docs updated in the same PR
+
+PRs target `dev`, not `main`.
+
+## Security
+
+This is an identity server. Some things are not stylistic:
+
+- **Never log a token, password, secret or session identifier** — not even truncated, not even in development.
+- **Validate redirect targets against an allowlist.** `matchesRedirectUri` in `src/common/redirect-uri.utils.ts` is the one implementation; don't write a second.
+- **Cookies:** `httpOnly`, `secure`, and the narrowest `sameSite` and `path` the flow permits. Widening an existing cookie's scope affects every flow that reads it — add a new one instead.
+- **A wrong authorisation decision still returns 200.** Tests are the only thing standing between a broken permission check and a green build.
+
+Suspected vulnerability? [`SECURITY.md`](https://github.com/idenplane/idenplane/blob/main/SECURITY.md), not a public issue.

--- a/docs/docs/contributing/development-setup.mdx
+++ b/docs/docs/contributing/development-setup.mdx
@@ -1,0 +1,130 @@
+---
+id: development-setup
+title: Development Environment Setup
+description: Get Idenplane running locally on macOS, Linux or Windows (WSL) — prerequisites, the three services you can run, and the failures people actually hit.
+---
+
+# Development Environment Setup
+
+[`CONTRIBUTING.md`](https://github.com/idenplane/idenplane/blob/main/CONTRIBUTING.md) has the six-command version. This page is for when one of those commands doesn't do what it says.
+
+## Prerequisites
+
+| | version | why that one |
+|---|---|---|
+| Node.js | **22+** | what CI runs (`.github/workflows/ci.yml`). 20 mostly works; nothing verifies it |
+| npm | 10+ | ships with Node 22 |
+| Docker + Compose | any current | only used for Postgres, unless you have your own |
+| Git | any current | |
+| Java 17 + | | **only** if you touch `packages/idenplane-java` — Maven comes from the wrapper |
+
+You do **not** need Maven installed. `packages/idenplane-java/mvnw` downloads a pinned version on first use.
+
+## macOS / Linux / Windows
+
+The commands below are identical on all three — with one condition on Windows.
+
+:::warning Windows: use WSL 2, not PowerShell
+The repo has shell scripts (`seed.sh`, `mvnw`, `docker-entrypoint.sh`) and `.gitattributes` forcing LF on them. Under native Windows git they still check out fine, but running them needs a POSIX shell.
+
+Clone **inside** the WSL filesystem (`~/code/idenplane`), not under `/mnt/c/`. Node's file watching across the Windows/Linux boundary is slow enough to make `start:dev` feel broken.
+:::
+
+## The three things you can run
+
+They're independent. Most changes need only one.
+
+### Backend (NestJS, port 3000)
+
+```bash
+npm install
+cp .env.example .env        # then edit — see below
+docker compose up -d db     # Postgres on 127.0.0.1:5432
+npm run db:setup            # migrate + seed
+npm run start:dev
+```
+
+`db:setup` is `prisma migrate dev && ts-node prisma/seed.ts`. To run them separately use `npm run prisma:migrate` and `npm run prisma:seed`.
+
+### Admin console (React + Vite)
+
+```bash
+cd admin-ui
+npm install
+npm run dev
+```
+
+It proxies to the backend on 3000, so run that first, or you'll get a console full of network errors and a login page that never accepts anything.
+
+### Docs site (Docusaurus)
+
+```bash
+cd docs
+npm install
+npm start
+```
+
+Independent of everything else — no backend, no database.
+
+## What actually needs setting in `.env`
+
+`cp .env.example .env` leaves four `REPLACE_ME_...` placeholders. For local development:
+
+```bash
+ADMIN_API_KEY=$(openssl rand -hex 32)
+ADMIN_PASSWORD=whatever-you-will-remember
+WEBHOOK_SECRET_KEY=$(openssl rand -hex 32)
+WEBHOOK_ENCRYPTION_SALT=$(openssl rand -hex 16)
+```
+
+`DATABASE_URL` already matches what `docker compose` starts, so leave it unless you're using your own Postgres.
+
+`ADMIN_API_KEY` is refused at startup in production if it's a known placeholder or under 32 characters (`src/main.ts`). In development it only warns — but generate a real one anyway, since it's the same value you'll paste into API calls.
+
+## Running the tests
+
+```bash
+npm test                    # backend unit — no database needed
+npm run test:e2e            # backend e2e — needs Postgres running
+cd admin-ui && npm test     # console, vitest + MSW, fully mocked
+cd packages/idenplane-java && ./mvnw verify   # Java SDK
+```
+
+Only `test:e2e` needs the database up. The rest are self-contained.
+
+## Failures people actually hit
+
+**`Can't reach database server at localhost:5432`**
+Postgres isn't up, or it's up in another container from another project holding the port. `docker compose ps` to check, `docker compose up -d db` to start it.
+
+**`Unique constraint failed` when seeding**
+The seed is not idempotent. Either you've already seeded, or a previous run half-completed. `npx prisma migrate reset` drops, re-migrates and re-seeds in one step.
+
+**`@prisma/client did not initialize yet`**
+The generated client is missing — it isn't committed, and it isn't regenerated automatically after a schema change. `npm run prisma:generate`. This is also what `Property 'x' does not exist on type 'PrismaService'` means after you edit `schema.prisma`.
+
+**Admin console loads but every request fails**
+The backend isn't running on 3000. Vite serves the console fine on its own; nothing about the page tells you the API is absent.
+
+**`bad interpreter: /bin/sh^M`**
+A shell script checked out with CRLF. `.gitattributes` prevents this for tracked scripts — if you see it, you're on a checkout older than that file, or an editor rewrote the line endings. `git checkout -- <file>` restores it.
+
+**Java build can't find Maven**
+It shouldn't need to. Run `./mvnw` from `packages/idenplane-java`, not `mvn`.
+
+## Where things live
+
+```
+src/                    NestJS backend, ~60 self-contained modules
+admin-ui/               React admin console
+docs/                   this site
+packages/idenplane-*/   published SDKs (JS, Go, Java, MCP, CLI)
+examples/               runnable quickstarts
+prisma/schema.prisma    the single source of truth for the data model
+```
+
+See [Architecture](./architecture.mdx) for how the backend modules relate, and [Coding Standards](./coding-standards.mdx) for what a change is expected to look like.
+
+## Still stuck
+
+Open a [discussion](https://github.com/idenplane/idenplane/discussions) — and if the fix belongs on this page, say so, because it means someone else will hit it too.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -246,8 +246,18 @@ const sidebars: SidebarsConfig = {
       items: [
         {
           type: 'doc',
+          id: 'contributing/development-setup',
+          label: 'Development Setup',
+        },
+        {
+          type: 'doc',
           id: 'contributing/architecture',
           label: 'Architecture Overview',
+        },
+        {
+          type: 'doc',
+          id: 'contributing/coding-standards',
+          label: 'Coding Standards',
         },
         {
           type: 'doc',


### PR DESCRIPTION
Closes the two remaining acceptance criteria on #1316. Architecture overview and the 10 ADRs landed in #1341 and #1399; this is the dev-environment guide and the coding standards document.

## First: CONTRIBUTING.md told new contributors to run commands that don't exist

Steps 4 and 5 of Development Setup — **the first thing anyone follows**:

```bash
npm run db:migrate    # not defined
npm run db:seed       # not defined
```

The real scripts are `prisma:migrate`, `prisma:seed`, and `db:setup` for both. The Database Guidelines section had two more undefined ones (`db:migrate:create`, `db:reset`).

Every `npm run` reference in the file now resolves against `package.json` — I checked each one, not just the ones I touched.

## Development Setup

The three things that can be run independently (backend, admin console, docs site), what actually has to go in `.env`, and a failures section built from real ones:

- the seed isn't idempotent → `Unique constraint failed`
- ungenerated Prisma client → `Property 'x' does not exist on type 'PrismaService'`
- admin console silently failing when the backend isn't up
- `bad interpreter: /bin/sh^M` from CRLF on shell scripts

Windows guidance is **WSL 2 with the clone inside the Linux filesystem** — the repo has shell scripts and LF-forced `.gitattributes`, and `/mnt/c` file watching makes `start:dev` look broken.

## Coding Standards

Written from what the tooling enforces, **checked rather than assumed** — which turned up a contradiction worth recording:

> `CONTRIBUTING.md` says "no `any`". But `@typescript-eslint/no-explicit-any` is **off**, and there are ~22 explicit `any` annotations in `src/`.

The page states what's actually true (`noImplicitAny` on, explicit `any` allowed at boundaries) rather than repeating a rule nothing checks.

Same for coverage: the 80% gate is **jacoco on the Java SDK only**. TypeScript coverage is collected and *not* gated — and the page says so, because pretending otherwise is how people assume CI is catching something it isn't.

The rest is conventions lifted from existing code: realm scoping via guard not parameter, per-method rate limiting where a class-level decorator would be wrong, the routes-to-nav guard, no helper exports beside components (Fast Refresh), one redirect-URI allowlist implementation, and testing the *refusals* in security-adjacent code rather than only the happy path.

## Verification

```
docs build   exit 0, no broken links
every npm script referenced in CONTRIBUTING.md resolves
```

## Still open on #1316 — both need you, not me

- **Dev setup verified on macOS / Linux / WSL.** I can't honestly tick this: it needs actually running it on each platform.
- **The "good first issue" labelling pass.** The issue itself says the maintainer is best placed to judge what's genuinely approachable.

So this PR says `Refs`, not `Closes`.

Refs #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)