### PR TITLE
release: dependency updates and contributor documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,14 +40,16 @@ cp .env.example .env
 docker compose up -d
 ```
 
-4. **Run database migrations**
+4. **Run migrations and seed development data**
 ```bash
-npm run db:migrate
+npm run db:setup
 ```
 
-5. **Seed development data**
+Or separately, if you only want one of them:
+
 ```bash
-npm run db:seed
+npm run prisma:migrate   # apply migrations
+npm run prisma:seed      # seed development data
 ```
 
 6. **Start development server**
@@ -219,13 +221,13 @@ For the full module map, grouped by concern, with a system diagram, see the [Arc
 
 ```bash
 # Create a new migration
-npm run db:migrate:create -- --name add_new_table
+npm run prisma:migrate -- --name add_new_table
 
 # Apply migrations
-npm run db:migrate
+npm run prisma:migrate
 
-# Reset database (development only)
-npm run db:reset
+# Reset database (development only) — drops, re-migrates and re-seeds
+npx prisma migrate reset
 ```
 
 ## Reporting Issues

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -28,7 +28,7 @@
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.1.0",
         "@vitest/coverage-v8": "^4.1.11",
-        "eslint": "^10.8.1",
+        "eslint": "^10.9.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.4",
         "globals": "^17.11.0",
@@ -2696,9 +2696,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.0.tgz",
+      "integrity": "sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -35,7 +35,7 @@
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.1.0",
     "@vitest/coverage-v8": "^4.1.11",
-    "eslint": "^10.8.1",
+    "eslint": "^10.9.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.4",
     "globals": "^17.11.0",

--- a/docs/docs/contributing/coding-standards.mdx
+++ b/docs/docs/contributing/coding-standards.mdx
@@ -1,0 +1,131 @@
+---
+id: coding-standards
+title: Coding Standards
+description: What a change to Idenplane is expected to look like — naming, module structure, testing expectations, and the PR checklist, as the tooling actually enforces them.
+---
+
+# Coding Standards
+
+Written from what the repo enforces and what its existing code does, not from what would be nice. Where the tooling doesn't enforce something, that's said plainly, because a rule nobody checks is a rule that drifts.
+
+## What the tooling actually enforces
+
+Run before pushing. CI runs all of these:
+
+```bash
+npm run lint         # eslint + prettier, errors fail the build
+npm test             # jest
+npm run build        # tsc via nest build
+```
+
+**ESLint** (`eslint.config.mjs`):
+
+| rule | level |
+|---|---|
+| `prettier/prettier` | **error** — formatting is not a matter of taste here |
+| `@typescript-eslint/no-unused-vars` | **error**, `_`-prefixed names exempt |
+| `@typescript-eslint/no-floating-promises` | warn |
+| `@typescript-eslint/no-unsafe-argument` | warn |
+| `@typescript-eslint/no-explicit-any` | **off** |
+
+**TypeScript** (`tsconfig.json`): `strictNullChecks` and `noImplicitAny` are on. Full `strict` is not.
+
+:::note `any` is allowed, and used
+`CONTRIBUTING.md` says "no `any`". The linter disagrees — the rule is off, and there are ~22 explicit `any` annotations in `src/`. Treat it as: **don't reach for `any` first**, and don't add one where a real type is obvious. But you will find it in the codebase, mostly at boundaries where a third-party type is wrong or missing, and adding one there isn't a review failure.
+
+`noImplicitAny` *is* on, so an *accidental* `any` from an un-annotated parameter is still a build error. That's the line the tooling draws.
+:::
+
+## Backend module structure
+
+`src/` has ~60 NestJS modules. A new one follows the same shape as its neighbours:
+
+```
+src/<feature>/
+  <feature>.module.ts        wires it up; imports what it needs
+  <feature>.controller.ts    HTTP layer — no business logic
+  <feature>.service.ts       business logic; where Prisma is called
+  <feature>.service.spec.ts  unit tests, colocated
+  dto/
+    create-<feature>.dto.ts  class-validator decorators
+    update-<feature>.dto.ts  usually PartialType(OmitType(Create..., [...]))
+```
+
+Then register it in `src/app.module.ts`.
+
+Conventions worth copying rather than re-deriving:
+
+- **Controllers stay thin.** Guards, decorators, Swagger annotations, delegate to the service. If a controller has an `if` that isn't a guard clause, it probably belongs in the service.
+- **Realm scoping is a guard, not a parameter you check.** `@UseGuards(RealmGuard)` plus `@CurrentRealm() realm: Realm`. Never read `realmName` from params yourself.
+- **Admin endpoints** live under `admin/realms/:realmName/<feature>` with `AdminApiKeyGuard`. Public ones live under `realms/:realmName/<feature>` with `@Public()`.
+- **Rate limiting is per-method where it matters.** A class-level `@RateLimitByIp()` covers every route, which is wrong for anything a proxy or a poller calls on every request — see the comment in `src/proxy-auth/proxy-auth.controller.ts` for a case where it would have throttled an entire application.
+- **DTO validation is not optional.** Every request body goes through a class-validator DTO. The global `ValidationPipe` strips unknown properties; a field you forget to declare is a field that silently disappears.
+
+## Prisma
+
+- `prisma/schema.prisma` is the single source of truth. Never hand-edit generated client code.
+- After changing the schema: `npm run prisma:generate`. `Property 'x' does not exist on type 'PrismaService'` almost always means you skipped it.
+- **Migrations are additive.** Adding a column or table is routine. Dropping or renaming one needs a plan for deployed instances — say so in the PR rather than leaving the reviewer to notice.
+- Name migrations for what they do: `add_proxy_applications`, not `update_schema`.
+- Store secrets as hashes, not plaintext. Session tokens use SHA-256 (`CryptoService.sha256`); passwords use Argon2id. Anything needing to be read back later uses `CryptoService.encrypt` (AES-256-GCM).
+
+## Admin console
+
+- React Query for server state — `useQuery` / `useMutation`, keyed by `[resource, realmName]`. No `useEffect` fetching.
+- Semantic Tailwind tokens (`bg-surface`, `text-fg`, `bg-danger-soft`), never raw colours. Dark mode comes free; a hardcoded `bg-white` breaks it.
+- Every route in `App.tsx` needs a nav entry in `Layout.tsx` — `src/__tests__/routes.test.ts` enforces this and will fail the build otherwise. Detail pages and `/new` pages are exempt by existing rules.
+- Don't export a helper from a page component file. It breaks React Fast Refresh (`react-refresh/only-export-components`); put it in `src/utils/`.
+
+## Testing
+
+| suite | command | needs |
+|---|---|---|
+| backend unit | `npm test` | nothing |
+| backend e2e | `npm run test:e2e` | Postgres running |
+| admin console | `cd admin-ui && npm test` | nothing (MSW mocks the API) |
+| Java SDK | `cd packages/idenplane-java && ./mvnw verify` | Java 17 |
+
+**Coverage gates:** only the Java SDK has one — jacoco, 80% line coverage, enforced in `pom.xml`. TypeScript coverage is collected but not gated. That's not permission to skip tests; it means review is the only thing catching an untested change.
+
+What's expected:
+
+- **New service method → unit test.** Mock Prisma, assert the behaviour, not the implementation.
+- **New endpoint → controller test or e2e**, depending on whether the interesting part is the wiring or the flow.
+- **Bug fix → a test that fails without the fix.** Otherwise nothing stops it coming back.
+- **Security-adjacent code → test the refusals**, not just the happy path. A session validator needs a test proving it rejects an expired session, one from a different application, and one belonging to a disabled user — the passing case is the easy half.
+
+Use the shared Prisma mock (`src/prisma/prisma.mock.ts`) rather than hand-rolling one, and add your model to it if it's missing.
+
+## Commits and PRs
+
+Conventional commits, as `CONTRIBUTING.md` describes:
+
+```
+type(scope): short description
+```
+
+The body is worth more than the subject. **Say why, not what** — the diff already shows what. If you rejected an alternative approach, one line about why saves the next person from trying it.
+
+Before opening a PR:
+
+- [ ] `npm run lint` clean
+- [ ] `npm test` passes
+- [ ] `npm run build` passes
+- [ ] Touched admin-ui? `cd admin-ui && npm run lint && npm test`
+- [ ] Touched Java? `cd packages/idenplane-java && ./mvnw verify`
+- [ ] Schema change? Migration committed, and it's additive (or the PR explains the plan)
+- [ ] New env var? Added to `.env.example` **and** the config docs
+- [ ] Behaviour change? Docs updated in the same PR
+
+PRs target `dev`, not `main`.
+
+## Security
+
+This is an identity server. Some things are not stylistic:
+
+- **Never log a token, password, secret or session identifier** — not even truncated, not even in development.
+- **Validate redirect targets against an allowlist.** `matchesRedirectUri` in `src/common/redirect-uri.utils.ts` is the one implementation; don't write a second.
+- **Cookies:** `httpOnly`, `secure`, and the narrowest `sameSite` and `path` the flow permits. Widening an existing cookie's scope affects every flow that reads it — add a new one instead.
+- **A wrong authorisation decision still returns 200.** Tests are the only thing standing between a broken permission check and a green build.
+
+Suspected vulnerability? [`SECURITY.md`](https://github.com/idenplane/idenplane/blob/main/SECURITY.md), not a public issue.

--- a/docs/docs/contributing/development-setup.mdx
+++ b/docs/docs/contributing/development-setup.mdx
@@ -1,0 +1,130 @@
+---
+id: development-setup
+title: Development Environment Setup
+description: Get Idenplane running locally on macOS, Linux or Windows (WSL) — prerequisites, the three services you can run, and the failures people actually hit.
+---
+
+# Development Environment Setup
+
+[`CONTRIBUTING.md`](https://github.com/idenplane/idenplane/blob/main/CONTRIBUTING.md) has the six-command version. This page is for when one of those commands doesn't do what it says.
+
+## Prerequisites
+
+| | version | why that one |
+|---|---|---|
+| Node.js | **22+** | what CI runs (`.github/workflows/ci.yml`). 20 mostly works; nothing verifies it |
+| npm | 10+ | ships with Node 22 |
+| Docker + Compose | any current | only used for Postgres, unless you have your own |
+| Git | any current | |
+| Java 17 + | | **only** if you touch `packages/idenplane-java` — Maven comes from the wrapper |
+
+You do **not** need Maven installed. `packages/idenplane-java/mvnw` downloads a pinned version on first use.
+
+## macOS / Linux / Windows
+
+The commands below are identical on all three — with one condition on Windows.
+
+:::warning Windows: use WSL 2, not PowerShell
+The repo has shell scripts (`seed.sh`, `mvnw`, `docker-entrypoint.sh`) and `.gitattributes` forcing LF on them. Under native Windows git they still check out fine, but running them needs a POSIX shell.
+
+Clone **inside** the WSL filesystem (`~/code/idenplane`), not under `/mnt/c/`. Node's file watching across the Windows/Linux boundary is slow enough to make `start:dev` feel broken.
+:::
+
+## The three things you can run
+
+They're independent. Most changes need only one.
+
+### Backend (NestJS, port 3000)
+
+```bash
+npm install
+cp .env.example .env        # then edit — see below
+docker compose up -d db     # Postgres on 127.0.0.1:5432
+npm run db:setup            # migrate + seed
+npm run start:dev
+```
+
+`db:setup` is `prisma migrate dev && ts-node prisma/seed.ts`. To run them separately use `npm run prisma:migrate` and `npm run prisma:seed`.
+
+### Admin console (React + Vite)
+
+```bash
+cd admin-ui
+npm install
+npm run dev
+```
+
+It proxies to the backend on 3000, so run that first, or you'll get a console full of network errors and a login page that never accepts anything.
+
+### Docs site (Docusaurus)
+
+```bash
+cd docs
+npm install
+npm start
+```
+
+Independent of everything else — no backend, no database.
+
+## What actually needs setting in `.env`
+
+`cp .env.example .env` leaves four `REPLACE_ME_...` placeholders. For local development:
+
+```bash
+ADMIN_API_KEY=$(openssl rand -hex 32)
+ADMIN_PASSWORD=whatever-you-will-remember
+WEBHOOK_SECRET_KEY=$(openssl rand -hex 32)
+WEBHOOK_ENCRYPTION_SALT=$(openssl rand -hex 16)
+```
+
+`DATABASE_URL` already matches what `docker compose` starts, so leave it unless you're using your own Postgres.
+
+`ADMIN_API_KEY` is refused at startup in production if it's a known placeholder or under 32 characters (`src/main.ts`). In development it only warns — but generate a real one anyway, since it's the same value you'll paste into API calls.
+
+## Running the tests
+
+```bash
+npm test                    # backend unit — no database needed
+npm run test:e2e            # backend e2e — needs Postgres running
+cd admin-ui && npm test     # console, vitest + MSW, fully mocked
+cd packages/idenplane-java && ./mvnw verify   # Java SDK
+```
+
+Only `test:e2e` needs the database up. The rest are self-contained.
+
+## Failures people actually hit
+
+**`Can't reach database server at localhost:5432`**
+Postgres isn't up, or it's up in another container from another project holding the port. `docker compose ps` to check, `docker compose up -d db` to start it.
+
+**`Unique constraint failed` when seeding**
+The seed is not idempotent. Either you've already seeded, or a previous run half-completed. `npx prisma migrate reset` drops, re-migrates and re-seeds in one step.
+
+**`@prisma/client did not initialize yet`**
+The generated client is missing — it isn't committed, and it isn't regenerated automatically after a schema change. `npm run prisma:generate`. This is also what `Property 'x' does not exist on type 'PrismaService'` means after you edit `schema.prisma`.
+
+**Admin console loads but every request fails**
+The backend isn't running on 3000. Vite serves the console fine on its own; nothing about the page tells you the API is absent.
+
+**`bad interpreter: /bin/sh^M`**
+A shell script checked out with CRLF. `.gitattributes` prevents this for tracked scripts — if you see it, you're on a checkout older than that file, or an editor rewrote the line endings. `git checkout -- <file>` restores it.
+
+**Java build can't find Maven**
+It shouldn't need to. Run `./mvnw` from `packages/idenplane-java`, not `mvn`.
+
+## Where things live
+
+```
+src/                    NestJS backend, ~60 self-contained modules
+admin-ui/               React admin console
+docs/                   this site
+packages/idenplane-*/   published SDKs (JS, Go, Java, MCP, CLI)
+examples/               runnable quickstarts
+prisma/schema.prisma    the single source of truth for the data model
+```
+
+See [Architecture](./architecture.mdx) for how the backend modules relate, and [Coding Standards](./coding-standards.mdx) for what a change is expected to look like.
+
+## Still stuck
+
+Open a [discussion](https://github.com/idenplane/idenplane/discussions) — and if the fix belongs on this page, say so, because it means someone else will hit it too.

--- a/docs/docs/contributing/development-setup.mdx
+++ b/docs/docs/contributing/development-setup.mdx
@@ -72,7 +72,7 @@ Independent of everything else — no backend, no database.
 
 ```bash
 ADMIN_API_KEY=$(openssl rand -hex 32)
-ADMIN_PASSWORD=whatever-you-will-remember
+ADMIN_PASSWORD=<pick your own>
 WEBHOOK_SECRET_KEY=$(openssl rand -hex 32)
 WEBHOOK_ENCRYPTION_SALT=$(openssl rand -hex 16)
 ```

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -246,8 +246,18 @@ const sidebars: SidebarsConfig = {
       items: [
         {
           type: 'doc',
+          id: 'contributing/development-setup',
+          label: 'Development Setup',
+        },
+        {
+          type: 'doc',
           id: 'contributing/architecture',
           label: 'Architecture Overview',
+        },
+        {
+          type: 'doc',
+          id: 'contributing/coding-standards',
+          label: 'Coding Standards',
         },
         {
           type: 'doc',

--- a/examples/nextjs-quickstart/package-lock.json
+++ b/examples/nextjs-quickstart/package-lock.json
@@ -20,8 +20,8 @@
         "@types/node": "^26.2.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "eslint": "^10.8.1",
-        "eslint-config-next": "^16.3.1",
+        "eslint": "^10.9.0",
+        "eslint-config-next": "^16.3.2",
         "typescript": "^7.0.2"
       }
     },
@@ -1195,9 +1195,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.3.1.tgz",
-      "integrity": "sha512-B4SznlXwVpaLDa7Tbi6zLuueria2d/PmFDhXyDymPGrk2r1n/RMJmcn5FZq1L64k+Jsyte1lKvOr7lP9Xo80mQ==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.3.2.tgz",
+      "integrity": "sha512-z+HW1cZgt8QhByw8p2EbxF94AImgsKIYUbtSkA7Zld2T9yrKAlys4jNOcAOCtv6csX2CoA/5qCVyesL5pHmJ0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3133,9 +3133,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.0.tgz",
+      "integrity": "sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -3192,13 +3192,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.3.1.tgz",
-      "integrity": "sha512-0vtrpwFVHFEkycUgV/DyrG29OS+HSRdah5Yu8YuZoiBMtlAT6NIiWzaLwDkJZxr2kGfx+9LIvfQ7KHAlEs0VsA==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.3.2.tgz",
+      "integrity": "sha512-gTABOJmyc6pEgSX1Z1VOjBxkSmo5Hkdj+ePclDf8HLGTsnVWzgtDdrOeQrAnUkf0JNJJhwPuXrsIwmFZRKJLoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.3.1",
+        "@next/eslint-plugin-next": "16.3.2",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",

--- a/examples/nextjs-quickstart/package-lock.json
+++ b/examples/nextjs-quickstart/package-lock.json
@@ -11,7 +11,7 @@
         "idenplane-nextjs": "^1.0.1",
         "idenplane-sdk": "^1.0.1",
         "jose": "^6.2.9",
-        "next": "^16.3.1",
+        "next": "^16.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.1.tgz",
-      "integrity": "sha512-35G3xwkQUb2oETSDjFXGrVugknoayLFBh7vSE+yAcl9IP2zT9wyGwq7297AYHR11kJld807t5f8AJBs6WBzXsQ==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.2.tgz",
+      "integrity": "sha512-8k4YoG8cM7LWlkfzGNYCRBbFNlernLiMw4s0btVl+CmmWqn3VpYypA72/5Feb1UWdxe6tHqr5KHP4p4Y4m9luA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1238,9 +1238,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.1.tgz",
-      "integrity": "sha512-ABMIu2zQ7cnNIHm5ivKGwZwUrm0pAai3yiJ/gK/rF1c1VP9UOnj7XECbMKFdVKp9I9eMYq9NoDs1WXOoowxzJw==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.2.tgz",
+      "integrity": "sha512-ib5Llm93YCKoKWDh6ZaHq6QWTuOZ2bRkSnUwMmX8dsRIOkBNL1vVlSiUKSfixPL9SSh9pvukzqajk/klkn5vqg==",
       "cpu": [
         "arm64"
       ],
@@ -1254,9 +1254,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.1.tgz",
-      "integrity": "sha512-gNG21e/UnrroeScbY/QndUEdl0mF1FRibW7BBeYUz/5ABCepjqDdEdgr592vpzMtCn/m7FTjYq3TN4TpyDnutw==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.2.tgz",
+      "integrity": "sha512-qd98fX2+I5nYJDioW2o7nSjoxM5KvWdeDefM80igia4+C/qSIEhH4MhTE+hO/7qKM7W37/Mq+dOWp8UePSyLHw==",
       "cpu": [
         "x64"
       ],
@@ -1270,9 +1270,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.1.tgz",
-      "integrity": "sha512-6B6Lw016iwNUQuaJoraMMTLh6TwHzFUtxipSScD1F3YyymcrRWkobodRS2ftIOkF5vrs4zNlyUrTC5YZQ9Lz5w==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.2.tgz",
+      "integrity": "sha512-vqsgb6FAOzcrCccsLXiKtAy5t8EzO+uOazuFaSkQxeY0tNONG3vpHYy8pyBafcI5SNFPTeyard6yTr6SzNGo2A==",
       "cpu": [
         "arm64"
       ],
@@ -1289,9 +1289,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.1.tgz",
-      "integrity": "sha512-JUiPXZKK9wOhjf4MgDiH29GZLxfqOesbLtHq2pDxwH/WwscTRV2ToymnOTh1egzaZf0ueUf8T2+CeYTGHjW0Iw==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.2.tgz",
+      "integrity": "sha512-xIe1eujfHUB2XcxHGddxJyu6TJRPjC5NpIkQYB/32ESkt5VkQyIAjmLRS38c+s6QY+qjtY/4KarVDzXRuD7lZQ==",
       "cpu": [
         "arm64"
       ],
@@ -1308,9 +1308,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.1.tgz",
-      "integrity": "sha512-Uog9jsrmIRIL/lfvIp9htmskSNC7JcQsMVucXL2V2YY1y/D9IUN3LPEafqy0zRJ2cIU1SQ0V6F6TlffQ+pLAGg==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.2.tgz",
+      "integrity": "sha512-Fe0SA2j8X0kmc3aveuHD7UktO3AE2+mH3LguP60vGbz7u0z+MrDXbeb5iZFYAwR7EzzzXJ2Yk966w9mGTFMqfA==",
       "cpu": [
         "x64"
       ],
@@ -1327,9 +1327,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.1.tgz",
-      "integrity": "sha512-6yy3FT13KgUFOj5H8bl8w/6nKiJwHIvbtwh1V+1acsu+7y4tJjnemSa6mhsh53BeoVrlozE+fMgZhXH46WmjMA==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.2.tgz",
+      "integrity": "sha512-TFBipb+gyesI/2Ve4zVu7kGltBWN/R466G5/1gtt2lECfc22G1pjkTxu68Q9aFcOaXiRGTQfvDbQQFe7mYgxiQ==",
       "cpu": [
         "x64"
       ],
@@ -1346,9 +1346,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.1.tgz",
-      "integrity": "sha512-iOoN1QecUoGNZik536U/vtK43YwgyrCsGIkth52yIkl612n+0C9MjSnJbQAikISpb+WYRooBVhaDlUW7iZoKog==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.2.tgz",
+      "integrity": "sha512-rVtmnNpBYIosDnKD/96dKxFsJnwnn1WRGG/HioSe8XCm2ksSHNrd2R6+hSjvTBxeMNhJ9pYeu/90cWB1nQLuNA==",
       "cpu": [
         "arm64"
       ],
@@ -1362,9 +1362,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.1.tgz",
-      "integrity": "sha512-d/k+PpAriUPaeMJJOG7HUSdqfEX46FEPWU1p3/nm2ACmXhj9hFEWdFODUBIpkuijXYkfL90qZzTqVPRp4BW/hw==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.2.tgz",
+      "integrity": "sha512-H4Y2o2/JcHu8LtwzD5CXfHhwxwz8gfsx2HXDEw46Mtev5xHnEmB7HNtZtmriw5ReUOjRtcDqo7XSbU01FT9NlA==",
       "cpu": [
         "x64"
       ],
@@ -5137,12 +5137,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.3.1.tgz",
-      "integrity": "sha512-hsAp0i7Rh+/dhe7DGIeN2YlpLM1DP4MNxti9EtDMtqcO612X81MvvEj388/oTce9U1EcEIOWDlGq0zRwrBKvuA==",
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.2.tgz",
+      "integrity": "sha512-/ZCaubUy17Lld1SiPWxuPbCk2ihqAxF2QNQaPZeEaEb7t1I58qhsJN187D7AfpapHAqUPXH0f/thtdW9dWgWFg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.3.1",
+        "@next/env": "16.3.2",
         "@swc/helpers": "0.5.23",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -5156,14 +5156,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.3.1",
-        "@next/swc-darwin-x64": "16.3.1",
-        "@next/swc-linux-arm64-gnu": "16.3.1",
-        "@next/swc-linux-arm64-musl": "16.3.1",
-        "@next/swc-linux-x64-gnu": "16.3.1",
-        "@next/swc-linux-x64-musl": "16.3.1",
-        "@next/swc-win32-arm64-msvc": "16.3.1",
-        "@next/swc-win32-x64-msvc": "16.3.1",
+        "@next/swc-darwin-arm64": "16.3.2",
+        "@next/swc-darwin-x64": "16.3.2",
+        "@next/swc-linux-arm64-gnu": "16.3.2",
+        "@next/swc-linux-arm64-musl": "16.3.2",
+        "@next/swc-linux-x64-gnu": "16.3.2",
+        "@next/swc-linux-x64-musl": "16.3.2",
+        "@next/swc-win32-arm64-msvc": "16.3.2",
+        "@next/swc-win32-x64-msvc": "16.3.2",
         "sharp": "^0.35.3"
       },
       "peerDependencies": {

--- a/examples/nextjs-quickstart/package.json
+++ b/examples/nextjs-quickstart/package.json
@@ -12,7 +12,7 @@
     "idenplane-sdk": "^1.0.1",
     "idenplane-nextjs": "^1.0.1",
     "jose": "^6.2.9",
-    "next": "^16.3.1",
+    "next": "^16.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/examples/nextjs-quickstart/package.json
+++ b/examples/nextjs-quickstart/package.json
@@ -21,8 +21,8 @@
     "@types/node": "^26.2.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "eslint": "^10.8.1",
-    "eslint-config-next": "^16.3.1",
+    "eslint": "^10.9.0",
+    "eslint-config-next": "^16.3.2",
     "typescript": "^7.0.2"
   },
   "overrides": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@types/sanitize-html": "^2.16.1",
         "@types/supertest": "^7.2.1",
         "@types/ws": "^8.18.1",
-        "eslint": "^10.8.1",
+        "eslint": "^10.9.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.5.6",
         "globals": "^17.11.0",
@@ -7672,9 +7672,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
-      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.0.tgz",
+      "integrity": "sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@types/sanitize-html": "^2.16.1",
     "@types/supertest": "^7.2.1",
     "@types/ws": "^8.18.1",
-    "eslint": "^10.8.1",
+    "eslint": "^10.9.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.5.6",
     "globals": "^17.11.0",

--- a/packages/idenplane-java/idenplane-java-core/pom.xml
+++ b/packages/idenplane-java/idenplane-java-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>idenplane-java-core</artifactId>

--- a/packages/idenplane-java/idenplane-java-jakarta/pom.xml
+++ b/packages/idenplane-java/idenplane-java-jakarta/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>idenplane-java-jakarta</artifactId>

--- a/packages/idenplane-java/idenplane-java-reactive/pom.xml
+++ b/packages/idenplane-java/idenplane-java-reactive/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>idenplane-java-reactive</artifactId>

--- a/packages/idenplane-java/idenplane-java-spring-sample/pom.xml
+++ b/packages/idenplane-java/idenplane-java-spring-sample/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>idenplane-java-spring-sample</artifactId>

--- a/packages/idenplane-java/idenplane-java-spring/pom.xml
+++ b/packages/idenplane-java/idenplane-java-spring/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>idenplane-java-spring</artifactId>

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -224,7 +224,7 @@
             <dependency>
                 <groupId>jakarta.ws.rs</groupId>
                 <artifactId>jakarta.ws.rs-api</artifactId>
-                <version>3.1.0</version>
+                <version>4.0.0</version>
             </dependency>
 
             <dependency>

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -127,7 +127,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>10.0.2</version>
+                <version>10.9.1</version>
             </dependency>
 
             <!-- Reactive -->

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.idenplane</groupId>
     <artifactId>idenplane-java</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <name>Idenplane Java SDK</name>

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -120,7 +120,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.22.1</version>
+                <version>2.22.2</version>
             </dependency>
 
             <!-- JWT -->

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -289,7 +289,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.0</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>


### PR DESCRIPTION
Promotes the 9 commits on `dev` since #1495.

## What's in it

**Java SDK dependencies** — all four built locally with `./mvnw verify` before merge, not merged on the green tick alone:

| | |
|---|---|
| #1505 | `jakarta.ws.rs-api` 3.1.0 → **4.0.0** (major) |
| #1503 | `nimbus-jose-jwt` 10.0.2 → 10.9.1 — JWT signature verification, so built locally despite being a minor |
| #1506 | `jackson-databind` 2.22.1 → 2.22.2 |
| #1504 | `maven-source-plugin` 3.3.0 → 3.4.0 |

On the major (#1505): `publish-java.yml` deploys **`idenplane-java-core` only**, and core doesn't reference `jakarta.ws.rs` at all. The module that does — `idenplane-java-jakarta` — isn't published, so no downstream consumer inherits it. `jersey-common` is on 4.0.2 (#1482), which implements JAX-RS 4, so the runtime lines up.

**Tooling** — #1500, #1501, #1502, #1507: eslint, next, and example dev-dependency patches.

**Contributor documentation** (#1511) — the Development Setup and Coding Standards pages, plus a fix for something worth calling out: `CONTRIBUTING.md` was instructing new contributors to run `npm run db:migrate` and `npm run db:seed` in steps 4 and 5 of setup. Neither is defined in `package.json`. Two more undefined commands further down. Every `npm run` reference in the file now resolves.

## Risk

- **No schema changes, no migrations.** Nothing runs against a deployed database.
- Nothing touches `src/` — the only backend-adjacent changes are Java SDK dependencies and docs.

## What merging does

`docker-publish.yml` rebuilds and pushes `islamawad/idenplane:latest` (multi-arch amd64 + arm64), and `sync-dev-to-main.yml` fast-forwards `dev`. Maven Central and npm are **not** touched — those need explicit `java-v*` / `v*` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)