### PR TITLE
docs: use a placeholder for ADMIN_PASSWORD in the setup guide

### DIFF
--- a/docs/docs/contributing/development-setup.mdx
+++ b/docs/docs/contributing/development-setup.mdx
@@ -72,7 +72,7 @@ Independent of everything else — no backend, no database.
 
 ```bash
 ADMIN_API_KEY=$(openssl rand -hex 32)
-ADMIN_PASSWORD=whatever-you-will-remember
+ADMIN_PASSWORD=<pick your own>
 WEBHOOK_SECRET_KEY=$(openssl rand -hex 32)
 WEBHOOK_ENCRYPTION_SALT=$(openssl rand -hex 16)
 ```


### PR DESCRIPTION
The secret scanner flagged this line from #1511, blocking the release PR #1512:

```
ADMIN_PASSWORD=whatever-you-will-remember
```

**It's right to.** That's the shape of a real assignment with a real-looking value, and the scanner can't tell an illustrative one from a leaked one — which is exactly the property that makes it worth having.

## The fix belongs in the docs, not the filter

#1508 deliberately scoped the exclusion to values that **declare themselves throwaway** (`...-do-not-use-in-production`, `demo`, `sample`). Widening it to cover anything that merely *looks* harmless would erode the check for no benefit — the guide reads better with an obvious placeholder anyway:

```diff
-ADMIN_PASSWORD=whatever-you-will-remember
+ADMIN_PASSWORD=<pick your own>
```

`<pick your own>` sits inside a bash code fence, so MDX doesn't try to parse the angle brackets as JSX.

## Verified

- old line trips the scanner, new one doesn't (ran the filter directly, both directions)
- docs build exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)