### PR TITLE
release(java): 1.1.0

### DIFF
--- a/packages/idenplane-java/idenplane-java-core/pom.xml
+++ b/packages/idenplane-java/idenplane-java-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>idenplane-java-core</artifactId>

--- a/packages/idenplane-java/idenplane-java-jakarta/pom.xml
+++ b/packages/idenplane-java/idenplane-java-jakarta/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>idenplane-java-jakarta</artifactId>

--- a/packages/idenplane-java/idenplane-java-reactive/pom.xml
+++ b/packages/idenplane-java/idenplane-java-reactive/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>idenplane-java-reactive</artifactId>

--- a/packages/idenplane-java/idenplane-java-spring-sample/pom.xml
+++ b/packages/idenplane-java/idenplane-java-spring-sample/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>idenplane-java-spring-sample</artifactId>

--- a/packages/idenplane-java/idenplane-java-spring/pom.xml
+++ b/packages/idenplane-java/idenplane-java-spring/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>idenplane-java-spring</artifactId>

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.idenplane</groupId>
     <artifactId>idenplane-java</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <name>Idenplane Java SDK</name>


### PR DESCRIPTION
Version bump ahead of tagging `java-v1.1.0` for Maven Central. The SDK has been on 1.0.0 there since it was first published, and today's Java work isn't reachable by anyone until this ships.

## Why minor, not patch

The published artifact is **`idenplane-java-core`**, and its own source hasn't changed since 1.0.0. Its **managed dependencies have**, and they reach consumers transitively:

| | |
|---|---|
| `nimbus-jose-jwt` | 10.0.2 → **10.9.1** |
| `jackson-databind` | 2.22.1 → 2.22.2 |
| `httpclient5` | 5.6.3 → 5.6.4 |

`nimbus-jose-jwt` does the JWT signature verification consumers depend on. A nine-minor jump in that is wider than "patch" honestly describes.

## Why not major

No API surface changed. The Spring Boot 4 / Security 7 migration (#1499) lives in **`idenplane-java-spring`**, which is *not* published to Maven Central — so it doesn't reach anyone through this release. Calling it 2.0.0 would signal a break that consumers of `core` will not experience.

## How

`./mvnw versions:set -DnewVersion=1.1.0` across all six poms rather than editing by hand, so the parent and its five modules can't drift apart.

## Verified

```
./mvnw clean verify        BUILD SUCCESS — whole reactor
project.version (core)     1.1.0
```

That second one matters: `publish-java.yml` compares the `java-v*` tag against exactly this value and fails the release if they disagree.

## After this merges

Tagging `java-v1.1.0` triggers `publish-java.yml` → signed deploy of `idenplane-java-core` to Maven Central. That's permanent and not retractable, so it happens as a deliberate step after this lands, not as a side effect of it.

Refs #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)