### PR TITLE
ci: detect secrets in Authorization headers

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -77,6 +77,36 @@ jobs:
             exit 1
           fi
 
+          # Second detector, for the shape the first one structurally cannot see.
+          #
+          # The pattern above requires a ':' or '=' immediately before the value.
+          # In an Authorization header the value follows the SCHEME and a space —
+          # `Authorization: Bearer <token>` — so the token itself never sits after
+          # a delimiter, and no amount of tuning that pattern reaches it. The
+          # `bearer` keyword has been in it since the beginning, which suggests
+          # header-form secrets were always meant to be covered; the delimiter
+          # requirement just prevented it from ever matching one. (#1509)
+          #
+          # Kept as its own grep rather than widened into the first: accepting
+          # whitespace as a delimiter there was measured against six months of
+          # this repo's history and added 24 false positives — ordinary code like
+          # `if (bearerToken && !isTokenExpiredLocally(bearerToken))`, SQL
+          # `CREATE USER ... WITH PASSWORD`, and Go env-var defaults. This
+          # narrower form matched ZERO false positives across the entire history.
+          #
+          # The '...' exclusion keeps documentation quiet: every truncated example
+          # in docs/ writes the token elided, and a real leak never is.
+          HEADER_HITS=$(git diff origin/main...HEAD \
+              -- . ':(exclude)*.example' ':(exclude)*.sample' ':(exclude)*.template' ':(exclude)*.dist' \
+            | grep -E '^\+[^+]' \
+            | grep -E '[Aa]uthorization[^A-Za-z]*:[^A-Za-z]*(Bearer|Basic|Token)[[:space:]]+[A-Za-z0-9_.=-]{20,}' \
+            | grep -vE '\.\.\.' || true)
+          if [ -n "$HEADER_HITS" ]; then
+            echo "::error::Possible secret leaked in an Authorization header:"
+            echo "$HEADER_HITS"
+            exit 1
+          fi
+
       - name: Size limits for automated PRs
         run: |
           set -e


### PR DESCRIPTION
Closes #1509.

## The gap

The existing detector requires a `:` or `=` **immediately before the value**:

```
(api[_-]?key|secret|password|token|bearer)[^A-Za-z]*[:=][^A-Za-z]*[A-Za-z0-9_-]{20,}
```

In an Authorization header the value follows the **scheme and a space** — `Authorization: Bearer <token>` — so the token never sits after a delimiter. No tuning of that pattern reaches it. A GitHub PAT in a curl header went through untouched.

The `bearer` keyword has been in the pattern from the start, which suggests header-form secrets were always meant to be covered. The delimiter requirement just stopped it ever matching one.

## Why a second grep, not a wider first one

**This is measured, not stylistic.** #1509 proposed accepting whitespace as a delimiter in the original pattern. I ran that against six months of this repo's history:

| | false positives |
|---|---|
| current filter | 56 (baseline) |
| whitespace variant | **80** — +24 |
| **narrow header form** | **0 across the *entire* history** |

The 24 it added were ordinary code:

```
if (bearerToken && !isTokenExpiredLocally(bearerToken)) {
CREATE USER idenplane WITH PASSWORD 'your_secure_password';
envOr("IDENPLANE_ADMIN_PASSWORD", "e2e-test-admin-password"),
/** e.g. 'OIDC_GRANT_TYPE_REFRESH_TOKEN' */
```

A scanner that cries wolf gets ignored, which is worse than the gap it fixes. That's the exact caution I wrote into #1509 — this PR is that check actually being run.

## What it catches

| | |
|---|---|
| ✅ flagged | `Authorization: Bearer <jwt>` · `curl -H 'Authorization: Bearer ghp_...'` · `Proxy-Authorization: Bearer <pat>` · `Authorization: Basic <base64>` · `Authorization: Token <opaque>` |
| ✅ allowed | all 24 false positives above · docs examples with elided tokens (`eyJ...`) |

The `...` exclusion is what keeps documentation quiet: every truncated example in `docs/` writes the token elided, and a real leak never is.

## Verification

Not a hand-copy of the regex — I extracted the **actual `run:` script** from the parsed workflow, checked it with `sh -n`, and drove the header pipeline with fixtures in both directions.

## Noticed while measuring, left alone

The **pre-existing** detector produces 56 hits across six months of history — all illustrative values (`change-me-in-production`, `your-secure-api-key-here`) and Java identifiers. They're diff-scoped in CI so they never fire on an unrelated PR, but the signal-to-noise there is worth its own look. Out of scope here.

Closes #1509

🤖 Generated with [Claude Code](https://claude.com/claude-code)